### PR TITLE
fix: activity time precision

### DIFF
--- a/src/components/activity/ZTimeJudge.vue
+++ b/src/components/activity/ZTimeJudge.vue
@@ -51,7 +51,7 @@ function calculateLoss() {
 </script>
 
 <template>
-  <ElStatistic :value="real">
+  <ElStatistic :value="real" :precision="1">
     <template #title>
       <span style="display: inline-flex; align-items: center">
         {{ t(`activity.mode.${type}.name`) }}


### PR DESCRIPTION
The card now shows the '.5' correctly.